### PR TITLE
NPM package identification

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Build Status](https://travis-ci.org/alansouzati/gulp-jest.svg?branch=master)](https://travis-ci.org/alansouzati/gulp-jest)
-[![Code Climate](https://codeclimate.com/github/alansouzati/gulp-jest/badges/gpa.svg)](https://codeclimate.com/github/alansouzati/gulp-jest)
-[![Test Coverage](https://codeclimate.com/github/alansouzati/gulp-jest/badges/coverage.svg)](https://codeclimate.com/github/alansouzati/gulp-jest/coverage)
+[![Build Status](https://travis-ci.org/acierto/gulp-jest.svg?branch=master)](https://travis-ci.org/acierto/gulp-jest)
+[![Code Climate](https://codeclimate.com/github/acierto/gulp-jest/badges/gpa.svg)](https://codeclimate.com/github/acierto/gulp-jest)
+[![Test Coverage](https://codeclimate.com/github/acierto/gulp-jest/badges/coverage.svg)](https://codeclimate.com/github/acierto/gulp-jest/coverage)
 
 # [gulp](http://gulpjs.com)-jest
 
@@ -9,13 +9,13 @@ Gulp plugin for the Jest test library
 ## Installation
 
 ```bash
-$ npm install gulp-jest jest
+$ npm install gulp-jest-acierto jest
 ```
 
 ## Usage
 
 ```javascript
-var jest = require('gulp-jest').default;
+var jest = require('gulp-jest-acierto').default;
 
 gulp.task('jest', function () {
   return gulp.src('__tests__').pipe(jest({
@@ -30,7 +30,7 @@ gulp.task('jest', function () {
 
 ## `process.env.NODE_ENV`
 
-Unlike the `jest` CLI tool, `gulp-jest` does not automatically set `process.env.NODE_ENV` 
+Unlike the `jest` CLI tool, `gulp-jest-acierto` does not automatically set `process.env.NODE_ENV` 
 to be `test`. If you are using Webpack or Babel, you may need to manually set `process.env.NODE_ENV`
 prior to running the task itself.
 

--- a/package.json
+++ b/package.json
@@ -10,9 +10,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git://github.com/alansouzati/gulp-jest.git"
+    "url": "git://github.com/acierto/gulp-jest.git"
   },
   "authors": [
+      {
+      "name": "Bogdan Nechyporenko",
+      "url": "https://github.com/acierto"
+    },
     {
       "name": "Dominic Barker",
       "email": "dom.barker808@gmail.com",
@@ -26,9 +30,9 @@
   ],
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/alansouzati/gulp-jest/issues"
+    "url": "https://github.com/acierto/gulp-jest/issues"
   },
-  "homepage": "https://github.com/alansouzati/gulp-jest",
+  "homepage": "https://github.com/acierto/gulp-jest",
   "dependencies": {
     "plugin-error": "^1.0.1",
     "through2": "^3.0.1"


### PR DESCRIPTION
It's very confusing on NPM to see two `gulp-jest` results that have identical readmes, but from different repos. This makes it clear that this is NOT the same as gulp-jest